### PR TITLE
Fix Auto-pipeline Proxy Json Issue

### DIFF
--- a/pkg/auto-pipeline.test.ts
+++ b/pkg/auto-pipeline.test.ts
@@ -299,5 +299,40 @@ describe("Auto pipeline", () => {
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(1);
   });
+
+  test("should handle JSON commands correctly", async () => {
+
+    const redis = Redis.fromEnv({
+      latencyLogging: false,
+      enableAutoPipelining: true
+    });
+
+    // @ts-expect-error pipelineCounter is not in type but accessible
+    expect(redis.pipelineCounter).toBe(0);
+
+    const json = redis.json
+    const key = newKey()
+
+    const res = await Promise.all([
+      redis.set("foo1", "bar"),
+      redis.json.set("baz1", "$", { hello: "world" }),
+      redis.get("foo1"),
+      redis.json.get("baz1"),
+      redis.json.del("baz1"),
+      redis.json.get("baz1"),
+    ])
+
+    // @ts-expect-error pipelineCounter is not in type but accessible
+    expect(redis.pipelineCounter).toBe(1);
+
+    expect(res).toEqual([
+      "OK",
+      "OK",
+      "bar",
+      { hello: "world" },
+      1,
+      null
+    ])
+  })
 });
 

--- a/pkg/auto-pipeline.test.ts
+++ b/pkg/auto-pipeline.test.ts
@@ -310,9 +310,6 @@ describe("Auto pipeline", () => {
     // @ts-expect-error pipelineCounter is not in type but accessible
     expect(redis.pipelineCounter).toBe(0);
 
-    const json = redis.json
-    const key = newKey()
-
     const res = await Promise.all([
       redis.set("foo1", "bar"),
       redis.json.set("baz1", "$", { hello: "world" }),

--- a/pkg/auto-pipeline.ts
+++ b/pkg/auto-pipeline.ts
@@ -23,9 +23,6 @@ export function createAutoPipelineProxy(_redis: Redis, json?: boolean): Redis {
       }
 
       if (command === "json") {
-        // @ts-ignore returning a proxy with the commands in json so that
-        // the get command redis.json.get can be run with the same auto
-        // pipeline executor
         return createAutoPipelineProxy(redis, true);
       };
       

--- a/pkg/auto-pipeline.ts
+++ b/pkg/auto-pipeline.ts
@@ -36,16 +36,15 @@ export function createAutoPipelineProxy(_redis: Redis, json?: boolean): Redis {
           return redis[command as redisOnly];
       }
 
-      command = command as keyof Pipeline;
       // If the method is a function on the pipeline, wrap it with the executor logic
-      if (typeof redis.autoPipelineExecutor.pipeline[command] === "function") {
+      if (typeof redis.autoPipelineExecutor.pipeline[command as keyof Pipeline] === "function") {
         return (...args: CommandArgs<typeof Command>) => {
           // pass the function as a callback
           return redis.autoPipelineExecutor.withAutoPipeline((pipeline) => {
             if (json) {
               (pipeline.json[command as keyof Pipeline["json"]] as Function)(...args)
             } else {
-              (pipeline[command] as Function)(...args);
+              (pipeline[command as keyof Pipeline] as Function)(...args);
             }
           });
         };
@@ -53,7 +52,7 @@ export function createAutoPipelineProxy(_redis: Redis, json?: boolean): Redis {
 
       // if the property is not a function, a property of redis or "pipelineCounter"
       // simply return it from pipeline
-      return redis.autoPipelineExecutor.pipeline[command];
+      return redis.autoPipelineExecutor.pipeline[command as keyof Pipeline];
     },
   }) as Redis;
 }


### PR DESCRIPTION
### Issue

Since json commands are called with redis.json.get, redis.json returned the proxy and redis.json.get simply called the json.get of the pipeline of auto pipeline executor.

as response to redis.json.get, we simply returned the pipeline of auto executor with json.get called. This also added a command to the pipeline without incrementing `indexInCurrentPipeline`, essentially corrupting the auto pipeline.

### Solution

Added a json parameter to `createAutoPipelineProxy`. Returned a json proxy if command is json. Not the cleanest solution but it works.

I feel like we can go over the types in the proxy later on. It looks a bit messy.