### PR TITLE
feat: add keepAlive parameter

### DIFF
--- a/pkg/http.ts
+++ b/pkg/http.ts
@@ -94,6 +94,7 @@ export type HttpClientConfig = {
   retry?: RetryConfig;
   agent?: any;
   signal?: AbortSignal;
+  keepAlive?: boolean
 } & RequesterConfig;
 
 export class HttpClient implements Requester {
@@ -105,6 +106,7 @@ export class HttpClient implements Requester {
     signal?: AbortSignal;
     responseEncoding?: false | "base64";
     cache?: CacheSetting;
+    keepAlive: boolean
   };
 
   public readonly retry: {
@@ -119,6 +121,7 @@ export class HttpClient implements Requester {
       responseEncoding: config.responseEncoding ?? "base64", // default to base64
       cache: config.cache,
       signal: config.signal,
+      keepAlive: config.keepAlive ?? true
     };
 
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
@@ -175,7 +178,7 @@ export class HttpClient implements Requester {
       method: "POST",
       headers: this.headers,
       body: JSON.stringify(req.body),
-      keepalive: true,
+      keepalive: this.options.keepAlive,
       agent: this.options?.agent,
       signal: this.options.signal,
 

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -28,6 +28,7 @@ export type RedisConfigCloudflare = {
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
   signal?: AbortSignal;
+  keepAlive?: boolean;
 } & core.RedisOptions &
   RequesterConfig &
   Env;
@@ -69,13 +70,14 @@ export class Redis extends core.Redis {
       headers: { authorization: `Bearer ${config.token}` },
       responseEncoding: config.responseEncoding,
       signal: config.signal,
+      keepAlive: config.keepAlive,
     });
 
     super(client, {
       enableTelemetry: !env?.UPSTASH_DISABLE_TELEMETRY,
       automaticDeserialization: config.automaticDeserialization,
       latencyLogging: config.latencyLogging,
-      enableAutoPipelining: config.enableAutoPipelining
+      enableAutoPipelining: config.enableAutoPipelining,
     });
     // This is only added of the user has not disabled telemetry
     this.addTelemetry({

--- a/platforms/fastly.ts
+++ b/platforms/fastly.ts
@@ -26,6 +26,7 @@ export type RedisConfigFastly = {
    * referenced by name.
    */
   backend: string;
+  keepAlive?: boolean;
 } & core.RedisOptions &
   RequesterConfig;
 
@@ -67,6 +68,7 @@ export class Redis extends core.Redis {
       headers: { authorization: `Bearer ${config.token}` },
       options: { backend: config.backend },
       responseEncoding: config.responseEncoding,
+      keepAlive: config.keepAlive,
     });
 
     super(client, {

--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -56,6 +56,7 @@ export type RedisConfigNodejs = {
   signal?: AbortSignal;
   latencyLogging?: boolean;
   agent?: any;
+  keepAlive?: boolean;
 } & core.RedisOptions &
   RequesterConfig;
 
@@ -131,6 +132,7 @@ export class Redis extends core.Redis {
       responseEncoding: configOrRequester.responseEncoding,
       cache: configOrRequester.cache || "no-store",
       signal: configOrRequester.signal,
+      keepAlive: configOrRequester.keepAlive,
     });
 
     super(client, {


### PR DESCRIPTION
Adding a parameter to make it possible to set keepAlive to false.

This is needed in our data browser where large requests fail because of a limit when keepAlive is true. [See for more details](https://github.com/getsentry/sentry-javascript/issues/1464).

I tested the browser with keepAlive: false and I was able to set/update large values.