### PR TITLE
Resolve Auto Pipeline Arrappend Issue

### DIFF
--- a/pkg/auto-pipeline.test.ts
+++ b/pkg/auto-pipeline.test.ts
@@ -13,6 +13,7 @@ describe("Auto pipeline", () => {
   test("should execute all commands inside a Promise.all in a single pipeline", async () => {
     const persistentKey = newKey();
     const persistentKey2 = newKey();
+    const persistentKey3 = newKey();
     const scriptHash = await new ScriptLoadCommand(["return 1"]).exec(client);
 
     const redis = Redis.fromEnv({
@@ -143,10 +144,11 @@ describe("Auto pipeline", () => {
       redis.zscore(newKey(), "member"),
       redis.zunionstore(newKey(), 1, [newKey()]),
       redis.zunion(1, [newKey()]),
-      redis.json.set(newKey(), "$", { hello: "world" }),
+      redis.json.set(persistentKey3, '$', { log: ["one", "two"] }),
+      redis.json.arrappend(persistentKey3, "$.log", '"three"'),
     ]);
     expect(result).toBeTruthy();
-    expect(result.length).toBe(120); // returns
+    expect(result.length).toBe(121); // returns
     // @ts-expect-error pipelineCounter is not in type but accessible120 results
     expect(redis.pipelineCounter).toBe(1);
   });

--- a/pkg/auto-pipeline.ts
+++ b/pkg/auto-pipeline.ts
@@ -34,7 +34,10 @@ export function createAutoPipelineProxy(_redis: Redis, json?: boolean): Redis {
       }
 
       // If the method is a function on the pipeline, wrap it with the executor logic
-      if (typeof redis.autoPipelineExecutor.pipeline[command as keyof Pipeline] === "function") {
+      const isFunction = json
+        ? typeof redis.autoPipelineExecutor.pipeline.json[command as keyof Pipeline["json"]] === "function"
+        : typeof redis.autoPipelineExecutor.pipeline[command as keyof Pipeline] === "function"
+      if (isFunction) {
         return (...args: CommandArgs<typeof Command>) => {
           // pass the function as a callback
           return redis.autoPipelineExecutor.withAutoPipeline((pipeline) => {


### PR DESCRIPTION
when a redis method which is available in .json but not available in the pipeline is used while auto pipeline is enabled, proxy doesn't check properly that the method is a function and attempts to return from pipeline, instead of pipeline.json.