### PR TITLE
Enable auto pipelining by default

### DIFF
--- a/pkg/redis.ts
+++ b/pkg/redis.ts
@@ -207,7 +207,7 @@ export class Redis {
     this.client = client;
     this.opts = opts;
     this.enableTelemetry = opts?.enableTelemetry ?? true;
-    this.enableAutoPipelining = opts?.enableAutoPipelining ?? false;
+    this.enableAutoPipelining = opts?.enableAutoPipelining ?? true;
   }
 
   get json() {


### PR DESCRIPTION
Auto pipelining allows the client to batch requests whenever possible. See [our docs](https://upstash.com/docs/oss/sdks/ts/redis/pipelining/auto-pipeline) to learn more.

This PR enables auto pipelining by default.