### PR TITLE
Fix TS5084 Error in Bitfield SubCommandArgs

### DIFF
--- a/pkg/commands/bitfield.ts
+++ b/pkg/commands/bitfield.ts
@@ -4,7 +4,7 @@ import { Command, type CommandOptions } from "./command";
 type SubCommandArgs<TRest extends unknown[] = []> = [
   encoding: string, // u1 - u63 | i1 - i64
   offset: number | string, // <int> | #<int>
-  ...TRest,
+  ...rest: TRest,
 ];
 
 /**


### PR DESCRIPTION
Should fix #1231 by adding the missing name to the tuple type `SubCommandArgs`.