### PR TITLE
chore: remove cron from github flow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: "0 0 * * *" # daily
 
 env:
   UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 
-bun run fmt && bun run test
+bun run fmt


### PR DESCRIPTION
- Remove tests from the pre-commit process.
- Remove the cron job from the GitHub test workflow to avoid flaky test execution. We don't want the large "Tests are failing" tag to appear when a test fails.