### PR TITLE
In auto pipeline, throw errors seperately

### DIFF
--- a/pkg/auto-pipeline.ts
+++ b/pkg/auto-pipeline.ts
@@ -1,6 +1,6 @@
 import type { Command } from "./commands/command";
 import { UpstashError } from "./error";
-import { UpstashResponse } from "./http";
+import type { UpstashResponse } from "./http";
 import type { Pipeline } from "./pipeline";
 import type { Redis } from "./redis";
 import type { CommandArgs } from "./types";
@@ -88,7 +88,7 @@ class AutoPipelineExecutor {
 
     const pipelineDone = this.deferExecution().then(() => {
       if (!this.pipelinePromises.has(pipeline)) {
-        const pipelinePromise = pipeline.exec(true);
+        const pipelinePromise = pipeline.exec({ keepErrors: true });
         this.pipelineCounter += 1;
 
         this.pipelinePromises.set(pipeline, pipelinePromise);

--- a/pkg/pipeline.test.ts
+++ b/pkg/pipeline.test.ts
@@ -288,7 +288,7 @@ describe("keep errors", () => {
     p.evalsha("wrong-sha1", [], []);
     p.get("foo");
     p.get("bar");
-    const results = await p.exec({ keepErrors: true });
+    const results = await p.exec<[string, string, string, number, number]>({ keepErrors: true });
 
     expect(results[0].error).toBeUndefined();
     expect(results[1].error).toBeUndefined();

--- a/pkg/pipeline.test.ts
+++ b/pkg/pipeline.test.ts
@@ -296,6 +296,7 @@ describe("keep errors", () => {
     expect(results[3].error).toBeUndefined();
     expect(results[4].error).toBeUndefined();
 
+    expect(results[2].result).toBeUndefined();
     expect(results[3].result).toBe(1);
     expect(results[4].result).toBe(2);
   });

--- a/pkg/pipeline.ts
+++ b/pkg/pipeline.ts
@@ -215,7 +215,7 @@ interface ExecMethod<TCommands extends Command<any, any>[]> {
     TCommandResults extends unknown[] = [] extends TCommands
       ? unknown[]
       : InferResponseData<TCommands>,
-  >(): Promise<[] extends TCommands ? unknown[] : TCommandResults>;
+  >(): Promise<TCommandResults>;
   <
     TCommandResults extends unknown[] = [] extends TCommands
       ? unknown[]

--- a/pkg/pipeline.ts
+++ b/pkg/pipeline.ts
@@ -185,6 +185,46 @@ type InferResponseData<T extends unknown[]> = {
   [K in keyof T]: T[K] extends Command<any, infer TData> ? TData : unknown;
 };
 
+interface ExecMethod<TCommands extends Command<any, any>[]> {
+  /**
+   * Send the pipeline request to upstash.
+   *
+   * Returns an array with the results of all pipelined commands.
+   *
+   * If all commands are statically chained from start to finish, types are inferred. You can still define a return type manually if necessary though:
+   * ```ts
+   * const p = redis.pipeline()
+   * p.get("key")
+   * const result = p.exec<[{ greeting: string }]>()
+   * ```
+   *
+   * If one of the commands get an error, the whole pipeline fails. Alternatively, you can set the keepErrors option to true in order to get the errors individually.
+   *
+   * If keepErrors is set to true, a list of objects is returned where each object corresponds to a command and is of type: `{ result: unknown, error?: string }`.
+   *
+   * ```ts
+   * const p = redis.pipeline()
+   * p.get("key")
+   *
+   * const result = await p.exec({ keepErrors: true });
+   * const getResult = result[0].result
+   * const getError = result[0].error
+   * ```
+   */
+  <
+    TCommandResults extends unknown[] = [] extends TCommands
+      ? unknown[]
+      : InferResponseData<TCommands>,
+  >(): Promise<[] extends TCommands ? unknown[] : TCommandResults>;
+  <
+    TCommandResults extends unknown[] = [] extends TCommands
+      ? unknown[]
+      : InferResponseData<TCommands>,
+  >(options: {
+    keepErrors: true;
+  }): Promise<{ [K in keyof TCommandResults]: UpstashResponse<TCommandResults[K]> }>;
+}
+
 /**
  * Upstash REST API supports command pipelining to send multiple commands in
  * batch, instead of sending each command one by one and waiting for a response.
@@ -246,9 +286,11 @@ export class Pipeline<TCommands extends Command<any, any>[] = []> {
         TCommandResults extends unknown[] = [] extends TCommands
           ? unknown[]
           : InferResponseData<TCommands>,
-      >(): Promise<TCommandResults> => {
+      >(options?: {
+        keepErrors: true;
+      }): Promise<TCommandResults> => {
         const start = performance.now();
-        const result = await originalExec();
+        const result = await (options ? originalExec(options) : originalExec());
         const end = performance.now();
         const loggerResult = (end - start).toFixed(2);
         // eslint-disable-next-line no-console
@@ -262,48 +304,7 @@ export class Pipeline<TCommands extends Command<any, any>[] = []> {
     }
   }
 
-  /**
-   * Send the pipeline request to upstash.
-   *
-   * Returns an array with the results of all pipelined commands.
-   *
-   * If all commands are statically chained from start to finish, types are inferred. You can still define a return type manually if necessary though:
-   * ```ts
-   * const p = redis.pipeline()
-   * p.get("key")
-   * const result = p.exec<[{ greeting: string }]>()
-   * ```
-   *
-   * If one of the commands get an error, the whole pipeline fails. Alternatively, you can set the keepErrors option to true in order to get the errors individually.
-   *
-   * If keepErrors is set to true, a list of objects is returned where each object corresponds to a command and is of type: `{ result: unknown, error?: string }`.
-   *
-   * ```ts
-   * const p = redis.pipeline()
-   * p.get("key")
-   *
-   * const result = await p.exec({ keepErrors: true });
-   * const getResult = result[0].result
-   * const getError = result[0].error
-   * ```
-   */
-  async exec<
-    TCommandResults extends unknown[] = [] extends TCommands
-      ? unknown[]
-      : InferResponseData<TCommands>,
-  >(): Promise<[] extends TCommands ? unknown[] : TCommandResults>;
-  async exec<
-    TCommandResults extends unknown[] = [] extends TCommands
-      ? unknown[]
-      : InferResponseData<TCommands>,
-  >(options: {
-    keepErrors: true;
-  }): Promise<{ [K in keyof TCommandResults]: UpstashResponse<TCommandResults[K]> }>;
-  async exec<
-    TCommandResults extends unknown[] = [] extends TCommands
-      ? unknown[]
-      : InferResponseData<TCommands>,
-  >(options?: { keepErrors: true }): Promise<UpstashResponse<any>[] | TCommandResults> {
+  exec: ExecMethod<TCommands> = async (options?: { keepErrors: true }) => {
     if (this.commands.length === 0) {
       throw new Error("Pipeline is empty");
     }
@@ -321,7 +322,7 @@ export class Pipeline<TCommands extends Command<any, any>[] = []> {
             result: this.commands[i].deserialize(result),
           };
         })
-      : (res.map(({ error, result }, i) => {
+      : res.map(({ error, result }, i) => {
           if (error) {
             throw new UpstashError(
               `Command ${i + 1} [ ${this.commands[i].command[0]} ] failed: ${error}`
@@ -329,8 +330,8 @@ export class Pipeline<TCommands extends Command<any, any>[] = []> {
           }
 
           return this.commands[i].deserialize(result);
-        }) as TCommandResults);
-  }
+        });
+  };
 
   /**
    * Returns the length of pipeline before the execution


### PR DESCRIPTION
Addressing the auto pipeline issue which causes https://github.com/upstash/ratelimit-js/issues/122

Essentially, when one of the commands in the pipeline fail, all threw an error in the autopipeline, which is not ideal. Fixing the issue by throwing the errors individually, in the auto pipeline code.