### PR TITLE
Remove sleep after the last retry attempt

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,7 +222,7 @@ jobs:
         run: sed -i 's;@upstash/redis@latest;@upstash/redis@${{needs.release.outputs.version}};' ./examples/deno/main.ts
 
       - name: Deploy
-        run: deno run -A https://deno.land/x/deploy/deployctl.ts deploy --project=upstash-redis ./main.ts
+        run: deno run -A https://deno.land/x/deploy@1.12.0/deployctl.ts deploy --project=upstash-redis ./main.ts
         working-directory: examples/deno
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}

--- a/examples/deno/main.ts
+++ b/examples/deno/main.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { Redis } from "https://esm.sh/@upstash/redis@latest";
 
 serve(async (_req: Request) => {

--- a/pkg/http.test.ts
+++ b/pkg/http.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "bun:test";
+import { Redis } from "../platforms/nodejs";
+
+describe("http", () => {
+  test("should terminate after sleeping 5 times", async () => {
+    // init a cient which will always get errors
+    const redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: "non-existent",
+      // set retry explicitly
+      retry: {
+        retries: 5,
+        backoff: (retryCount) => Math.exp(retryCount) * 50,
+      },
+    });
+
+    // get should take 4.287 seconds and terminate before the timeout.
+    const throws = () => Promise.race([redis.get("foo"), new Promise((r) => setTimeout(r, 4500))]);
+
+    // if the Promise.race doesn't throw, that means the retries took longer than 4.5s
+    expect(throws).toThrow("fetch() URL is invalid");
+  });
+});

--- a/pkg/http.test.ts
+++ b/pkg/http.test.ts
@@ -5,7 +5,7 @@ describe("http", () => {
   test("should terminate after sleeping 5 times", async () => {
     // init a cient which will always get errors
     const redis = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL,
+      url: undefined,
       token: "non-existent",
       // set retry explicitly
       retry: {

--- a/pkg/http.ts
+++ b/pkg/http.ts
@@ -243,7 +243,11 @@ export class HttpClient implements Requester {
           break;
         }
         error = error_ as Error;
-        await new Promise((r) => setTimeout(r, this.retry.backoff(i)));
+
+        // Only sleep if this is not the last attempt
+        if (i < this.retry.attempts) {
+          await new Promise((r) => setTimeout(r, this.retry.backoff(i)));
+        }
       }
     }
     if (!res) {


### PR DESCRIPTION
The http client would sleep event after the last retry, which resulted in the following behavior:

```
failing
sleeping 50
failing
sleeping 135.91409142295225
failing
sleeping 369.4528049465325
failing
sleeping 1004.2768461593834
failing
sleeping 2729.907501657212
failing
sleeping 7420.65795512883
throw
```

now the last sleep is removed. Error is thrown immedietly after the last (5th) retry failure.