### PR TITLE
introduce SUBSCRIBE command

### DIFF
--- a/pkg/commands/subscribe.test.ts
+++ b/pkg/commands/subscribe.test.ts
@@ -1,0 +1,130 @@
+import { expect, test, describe } from "bun:test";
+import { newHttpClient } from "../test-utils";
+import { SubscribeCommand } from "./subscribe";
+import { PublishCommand } from "./publish";
+
+describe("Subscribe Command", () => {
+  const client = newHttpClient();
+
+  test("receives a single published message", async () => {
+    const channel = "test-single";
+    const receivedMessages: any[] = [];
+
+    const subscription = new SubscribeCommand([channel], {
+      onMessage: (message) => {
+        receivedMessages.push(JSON.parse(message));
+      },
+    });
+
+    const subscribePromise = subscription.exec(client);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const testMessage = {
+      user: "testUser",
+      message: "Hello, World!",
+      timestamp: Date.now(),
+    };
+
+    await new PublishCommand([channel, JSON.stringify(testMessage)]).exec(client);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const result = await subscribePromise;
+    expect(result).toBe(1);
+    expect(receivedMessages).toHaveLength(1);
+    expect(receivedMessages[0]).toEqual(testMessage);
+  }, 10000);
+
+  test("receives multiple messages in order", async () => {
+    const channel = "test-multiple";
+    const receivedMessages: any[] = [];
+
+    const subscription = new SubscribeCommand([channel], {
+      onMessage: (message) => {
+        receivedMessages.push(JSON.parse(message));
+      },
+    });
+
+    const subscribePromise = subscription.exec(client);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const messages = [
+      { user: "user1", message: "First", timestamp: Date.now() },
+      { user: "user1", message: "Second", timestamp: Date.now() + 1 },
+      { user: "user1", message: "Third", timestamp: Date.now() + 2 },
+    ];
+
+    for (const msg of messages) {
+      await new PublishCommand([channel, JSON.stringify(msg)]).exec(client);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await subscribePromise;
+
+    expect(receivedMessages).toHaveLength(messages.length);
+    expect(receivedMessages.map((m) => m.message)).toEqual(messages.map((m) => m.message));
+  }, 15000);
+
+  test("uses default message handler when no handler provided", async () => {
+    const channel = "test-default";
+    const logs: any[] = [];
+    const originalLog = console.log;
+    console.log = (...args) => logs.push(args);
+
+    try {
+      const subscription = new SubscribeCommand([channel]);
+      const subscribePromise = subscription.exec(client);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const testMessage = {
+        user: "testUser",
+        message: "Test default",
+        timestamp: Date.now(),
+      };
+
+      await new PublishCommand([channel, JSON.stringify(testMessage)]).exec(client);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await subscribePromise;
+
+      expect(
+        logs.some(
+          (log) =>
+            log[0] === "message" && log[1] === channel && log[2].message === testMessage.message
+        )
+      ).toBe(true);
+    } finally {
+      console.log = originalLog;
+    }
+  }, 10000);
+
+  test("multiple subscribers receive same message", async () => {
+    const channel = "test-multi-sub";
+    const messages1: any[] = [];
+    const messages2: any[] = [];
+
+    const sub1 = new SubscribeCommand([channel], {
+      onMessage: (message) => messages1.push(JSON.parse(message)),
+    });
+    const sub2 = new SubscribeCommand([channel], {
+      onMessage: (message) => messages2.push(JSON.parse(message)),
+    });
+
+    const [promise1, promise2] = [sub1.exec(client), sub2.exec(client)];
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const testMessage = {
+      user: "testUser",
+      message: "Broadcast",
+      timestamp: Date.now(),
+    };
+
+    await new PublishCommand([channel, JSON.stringify(testMessage)]).exec(client);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    await Promise.all([promise1, promise2]);
+
+    expect(messages1[0]).toEqual(testMessage);
+    expect(messages2[0]).toEqual(testMessage);
+    expect(messages1).toEqual(messages2);
+  }, 15000);
+});

--- a/pkg/commands/subscribe.ts
+++ b/pkg/commands/subscribe.ts
@@ -1,0 +1,45 @@
+import type { CommandOptions } from "./command";
+import { Command } from "./command";
+
+/**
+ * @see https://redis.io/commands/subscribe
+ */
+export class SubscribeCommand extends Command<number, number> {
+  private defaultMessageHandler(data: string) {
+    if (data.startsWith("message,")) {
+      // Find the index of first comma and second comma
+      const firstComma = data.indexOf(",");
+      const secondComma = data.indexOf(",", firstComma + 1);
+
+      // Extract the channel and message parts
+      const channel = data.slice(firstComma + 1, secondComma);
+      const message = data.slice(Math.max(0, secondComma + 1));
+
+      const parsedMessage = JSON.parse(message);
+      console.log("message", channel, parsedMessage);
+      return message;
+    }
+    return null;
+  }
+
+  constructor(cmd: [channel: string], opts?: CommandOptions<number, number>) {
+    const sseHeaders = {
+      Accept: "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    };
+
+    super([], {
+      ...opts,
+      headers: sseHeaders,
+      path: ["subscribe", cmd[0]],
+      isStreaming: true,
+      onMessage: (data: string) => {
+        const message = this.defaultMessageHandler(data);
+        if (message && opts?.onMessage) {
+          opts.onMessage(message);
+        }
+      },
+    });
+  }
+}

--- a/pkg/util.ts
+++ b/pkg/util.ts
@@ -40,3 +40,33 @@ export function parseResponse<TResult>(result: unknown): TResult {
 export function deserializeScanResponse<TResult>(result: [string, ...any]): TResult {
   return [result[0], ...parseResponse<any[]>(result.slice(1))] as TResult;
 }
+
+/**
+ * Merges multiple Records of headers into a single Record
+ * Later headers take precedence over earlier ones.
+ *
+ * @param headers - Array of header records to merge
+ * @returns A new Record containing all merged headers
+ *
+ * @example
+ * const defaultHeaders = { 'Content-Type': 'application/json' };
+ * const customHeaders = { 'Authorization': 'Bearer token' };
+ * const merged = mergeHeaders(defaultHeaders, customHeaders);
+ */
+export function mergeHeaders(
+  ...headers: (Record<string, string> | undefined)[]
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+
+  for (const header of headers) {
+    if (!header) continue;
+
+    for (const [key, value] of Object.entries(header)) {
+      if (value !== undefined && value !== null) {
+        merged[key] = value;
+      }
+    }
+  }
+
+  return merged;
+}


### PR DESCRIPTION
This PR introduces Redis SUBSCRIBE command that uses SSE. The example usage is as below.

```typescript
await redis.subscribe(["chat"])
```
which will console.log the messages as below as default
```
message <CHANNEL> <DATA>
//message test-multiple {
//  user: "user1",
//  message: "First",
//  timestamp: 1739910028937
//}
```

you can also pass `onMessage` function to subscribe command to consume the raw string directly.

```typescript
await redis.subscribe(["chat"], {onMessage: (data)=>{
  console.log("MYDATA", data)
}})
```