### PR TITLE
Remove json.get options as they are not supported

### DIFF
--- a/pkg/commands/json_get.ts
+++ b/pkg/commands/json_get.ts
@@ -8,37 +8,9 @@ export class JsonGetCommand<
   TData extends (unknown | Record<string, unknown>) | (unknown | Record<string, unknown>)[],
 > extends Command<TData | null, TData | null> {
   constructor(
-    cmd:
-      | [
-          key: string,
-          opts?: { indent?: string; newline?: string; space?: string },
-          ...path: string[],
-        ]
-      | [key: string, ...path: string[]],
+    cmd: [key: string, ...path: string[]],
     opts?: CommandOptions<TData | null, TData | null>
   ) {
-    const command = ["JSON.GET"];
-    if (typeof cmd[1] === "string") {
-      // @ts-expect-error - we know this is a string
-      command.push(...cmd);
-    } else {
-      command.push(cmd[0]);
-
-      if (cmd[1]) {
-        if (cmd[1].indent) {
-          command.push("INDENT", cmd[1].indent);
-        }
-        if (cmd[1].newline) {
-          command.push("NEWLINE", cmd[1].newline);
-        }
-        if (cmd[1].space) {
-          command.push("SPACE", cmd[1].space);
-        }
-      }
-      // @ts-expect-error - we know this is a string
-      command.push(...cmd.slice(2));
-    }
-
-    super(command, opts);
+    super(["JSON.GET", ...cmd], opts);
   }
 }


### PR DESCRIPTION
Json.Get options such as indent, newline and space are not supported but they have been implemented in the SDK. Specifying them not only has no effect but causes command to fail entirely. Followings a snippet from Upstash Redis Console;

![image](https://github.com/user-attachments/assets/233fe0e2-9d20-4a93-a150-05840af4200f)

