### PR TITLE
Don't use Array.shift in custom deserializers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -316,7 +316,7 @@ jobs:
         working-directory: examples/cloudflare-workers
 
       - name: Deploy
-        run: wrangler publish
+        run: wrangler deploy
         working-directory: examples/cloudflare-workers
         env:
           CLOUDFLARE_API_TOKEN: ${{secrets.CF_API_TOKEN}}
@@ -409,7 +409,7 @@ jobs:
         working-directory: examples/cloudflare-workers-with-typescript
 
       - name: Deploy
-        run: wrangler publish
+        run: wrangler deploy
         working-directory: examples/cloudflare-workers-with-typescript
         env:
           CLOUDFLARE_API_TOKEN: ${{secrets.CF_API_TOKEN}}

--- a/pkg/commands/hgetall.ts
+++ b/pkg/commands/hgetall.ts
@@ -6,9 +6,9 @@ function deserialize<TData extends Record<string, unknown>>(result: string[]): T
     return null;
   }
   const obj: Record<string, unknown> = {};
-  while (result.length >= 2) {
-    const key = result.shift()!;
-    const value = result.shift()!;
+  for (let i = 0; i < result.length; i += 2) {
+    const key = result[i];
+    const value = result[i + 1];
     try {
       // handle unsafe integer
       const valueIsNumberAndNotSafeInteger =

--- a/pkg/commands/hrandfield.ts
+++ b/pkg/commands/hrandfield.ts
@@ -6,9 +6,9 @@ function deserialize<TData extends Record<string, unknown>>(result: string[]): T
     return null;
   }
   const obj: Record<string, unknown> = {};
-  while (result.length >= 2) {
-    const key = result.shift()!;
-    const value = result.shift()!;
+  for (let i = 0; i < result.length; i += 2) {
+    const key = result[i];
+    const value = result[i + 1];
     try {
       obj[key] = JSON.parse(value);
     } catch {

--- a/pkg/commands/xrange.ts
+++ b/pkg/commands/xrange.ts
@@ -6,16 +6,16 @@ function deserialize<TData extends Record<string, Record<string, unknown>>>(
 ): TData {
   const obj: Record<string, Record<string, unknown>> = {};
   for (const e of result) {
-    while (e.length >= 2) {
-      const streamId = e.shift() as string;
-      const entries = e.shift()!;
+    for (let i = 0; i < e.length; i += 2) {
+      const streamId = e[i] as string;
+      const entries = e[i + 1];
 
       if (!(streamId in obj)) {
         obj[streamId] = {};
       }
-      while (entries.length >= 2) {
-        const field = (entries as string[]).shift()!;
-        const value = (entries as string[]).shift()!;
+      for (let j = 0; j < entries.length; j += 2) {
+        const field = (entries as string[])[j];
+        const value = (entries as string[])[j + 1];
 
         try {
           obj[streamId][field] = JSON.parse(value);

--- a/pkg/commands/xrevrange.ts
+++ b/pkg/commands/xrevrange.ts
@@ -24,16 +24,16 @@ function deserialize<TData extends Record<string, Record<string, unknown>>>(
 ): TData {
   const obj: Record<string, Record<string, unknown>> = {};
   for (const e of result) {
-    while (e.length >= 2) {
-      const streamId = e.shift() as string;
-      const entries = e.shift()!;
+    for (let i = 0; i < e.length; i += 2) {
+      const streamId = e[i] as string;
+      const entries = e[i + 1];
 
       if (!(streamId in obj)) {
         obj[streamId] = {};
       }
-      while (entries.length >= 2) {
-        const field = (entries as string[]).shift()!;
-        const value = (entries as string[]).shift()!;
+      for (let j = 0; j < entries.length; j += 2) {
+        const field = (entries as string[])[j];
+        const value = (entries as string[])[j + 1];
 
         try {
           obj[streamId][field] = JSON.parse(value);

--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -185,7 +185,7 @@ export class Redis extends core.Redis {
     if (!url) {
       console.warn("[Upstash Redis] Unable to find environment variable: `UPSTASH_REDIS_REST_URL`");
     }
-    
+
     // @ts-ignore process will be defined in node
     const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
     if (!token) {


### PR DESCRIPTION
It is not a O(1) operation in Node.js (V8 engine). So, custom deserializers that were using it extensively like hgetall was running extremely slow on large payloads.

We are now using plain indexing to achieve the same thing.