### PR TITLE
DX-1938: update signal parameter to accept function

### DIFF
--- a/pkg/http.test.ts
+++ b/pkg/http.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { Redis } from "../platforms/nodejs";
+import { serve } from "bun";
+
+const MOCK_SERVER_PORT = 8080;
+const SERVER_URL = `http://localhost:${MOCK_SERVER_PORT}`;
 
 describe("http", () => {
   test("should terminate after sleeping 5 times", async () => {
@@ -19,5 +23,42 @@ describe("http", () => {
 
     // if the Promise.race doesn't throw, that means the retries took longer than 4.5s
     expect(throws).toThrow("fetch() URL is invalid");
+  });
+
+  test("should throw on request timeouts", async () => {
+    const server = serve({
+      async fetch(request) {
+        const body = await request.text();
+
+        if (body.includes("zed")) {
+          return new Response(JSON.stringify({ result: '"zed-result"' }), { status: 200 });
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        return new Response("Hello World");
+      },
+      port: MOCK_SERVER_PORT,
+    });
+
+    const redis = new Redis({
+      url: SERVER_URL,
+      token: "non-existent",
+      signal: () => AbortSignal.timeout(1000), // set a timeout of 1 second
+      // set to false since mock server doesn't return a response
+      // for a pipeline. If you want to test pipelining, you can set it to true
+      // and make the mock server return a pipeline response.
+      enableAutoPipelining: false,
+    });
+
+    try {
+      expect(redis.get("foo")).rejects.toThrow("The operation timed out.");
+      expect(redis.get("bar")).rejects.toThrow("The operation timed out.");
+      expect(redis.get("zed")).resolves.toBe("zed-result");
+    } catch (error) {
+      server.stop(true);
+      throw error;
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -1,4 +1,4 @@
-import type { RequesterConfig } from "../pkg/http";
+import type { HttpClientConfig, RequesterConfig } from "../pkg/http";
 import { HttpClient } from "../pkg/http";
 import * as core from "../pkg/redis";
 import { VERSION } from "../version";
@@ -27,7 +27,7 @@ export type RedisConfigCloudflare = {
    * The signal will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
-  signal?: AbortSignal;
+  signal?: HttpClientConfig["signal"];
   keepAlive?: boolean;
 
   /**

--- a/platforms/nodejs.ts
+++ b/platforms/nodejs.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // deno-lint-ignore-file
 
-import type { Requester, RequesterConfig } from "../pkg/http";
+import type { HttpClientConfig, Requester, RequesterConfig } from "../pkg/http";
 import { HttpClient } from "../pkg/http";
 
 import * as core from "../pkg/redis";
@@ -49,7 +49,7 @@ export type RedisConfigNodejs = {
    * The signal will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
-  signal?: AbortSignal;
+  signal?: HttpClientConfig["signal"];
   latencyLogging?: boolean;
   agent?: unknown;
   keepAlive?: boolean;


### PR DESCRIPTION
Currently, there is a signal parameter which accepts an AbortSignal but this has two limitations which make configuring request timeout not feasible:
1. If a request gets timeout, the `signal.aborted` field becomes true, and it stays true in subsequent requests as the object remains the same.
2. When we get a timeout, in the request method of HttpClient, a Response object is created with status 200. So the request method never throws an error. The response is simply null.

Did the following to fix the issue:
- Made it possible to pass an AbortSignal creator function as signal.
- When this is done, we simply throw the error which can be cought like this:

```ts
const redis = new Redis({
  url: "***",
  token: "***",
  signal: () => AbortSignal.timeout(500),
});

try {
  const count = await redis.hset("myhash", {
    key: null,
  });
} catch (error) {
  if (error instanceof Error && error.name === "TimeoutError") {
    console.error("Timeout: It took more than 500 ms to get the result!");
  }
}
```