### PR TITLE
chore: correct typo 'cound' to 'count' in http.ts comment

### DIFF
--- a/pkg/http.ts
+++ b/pkg/http.ts
@@ -68,7 +68,7 @@ export type RetryConfig =
        */
       retries?: number;
       /**
-       * A backoff function receives the current retry cound and returns a number in milliseconds to wait before retrying.
+       * A backoff function receives the current retry count and returns a number in milliseconds to wait before retrying.
        *
        * @default
        * ```ts


### PR DESCRIPTION
Fixed a typo in the JSDoc comment for the `backoff` function parameter.
- Changed "cound" to "count" in pkg/http.ts line 71
