### PR TITLE
DX-2161: fall back to returning the message string if message is not parsable

### DIFF
--- a/pkg/commands/subscribe.test.ts
+++ b/pkg/commands/subscribe.test.ts
@@ -16,16 +16,12 @@ describe("Subscriber", () => {
     });
 
     // Wait for subscription to establish
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    const testMessage = {
-      user: "testUser",
-      message: "Hello, World!",
-      timestamp: Date.now(),
-    };
+    const testMessage = "really?";
 
-    await redis.publish(channel, testMessage);
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await redis.publish(channel, JSON.stringify(testMessage));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     expect(receivedMessages).toHaveLength(1);
     expect(receivedMessages[0]).toEqual(testMessage);

--- a/pkg/commands/subscribe.test.ts
+++ b/pkg/commands/subscribe.test.ts
@@ -20,7 +20,7 @@ describe("Subscriber", () => {
 
     const testMessage = "really?";
 
-    await redis.publish(channel, JSON.stringify(testMessage));
+    await redis.publish(channel, testMessage);
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     expect(receivedMessages).toHaveLength(1);

--- a/pkg/commands/subscribe.ts
+++ b/pkg/commands/subscribe.ts
@@ -142,7 +142,7 @@ export class Subscriber<TMessage = any> extends EventTarget {
             this.dispatchToListeners(type, count);
           } else {
             // For regular messages, emit the full object
-            const message = JSON.parse(messageStr);
+            const message = parseWithTryCatch(messageStr);
             this.dispatchToListeners(type, { channel, message });
             this.dispatchToListeners(`${type}:${channel}`, { channel, message });
           }
@@ -230,3 +230,11 @@ export class SubscribeCommand extends Command<number, number> {
     });
   }
 }
+
+const parseWithTryCatch = (str: string) => {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return str;
+  }
+};


### PR DESCRIPTION
when the message was a string, we tried to parse which got an error. Also, test durations were too short and we were getting the subscribe event instead of the message event