### PR TITLE
DX-2861: trim telemetry dedup values

### DIFF
--- a/.changeset/trim-telemetry-dedup.md
+++ b/.changeset/trim-telemetry-dedup.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": patch
+---
+
+Trim telemetry header values before deduplicating so whitespace around existing values does not defeat the dedup check

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -244,5 +244,30 @@ describe("http", () => {
       );
       expect(client.headers["Upstash-Telemetry-Platform"]).toBe("vercel");
     });
+
+    test("keeps distinct versions of the same sdk", () => {
+      const client = new HttpClient({
+        baseUrl: SERVER_URL,
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      client.mergeTelemetry({ sdk: "@upstash/redis@1.0.0" });
+      client.mergeTelemetry({ sdk: "@upstash/redis@1.1.0" });
+
+      expect(client.headers["Upstash-Telemetry-Sdk"]).toBe(
+        "@upstash/redis@1.0.0,@upstash/redis@1.1.0"
+      );
+    });
+
+    test("ignores whitespace around existing values", () => {
+      const client = new HttpClient({
+        baseUrl: SERVER_URL,
+        headers: { authorization: "Bearer test-token", "Upstash-Telemetry-Sdk": "sdk-a, sdk-b" },
+      });
+
+      client.mergeTelemetry({ sdk: "sdk-b" });
+
+      expect(client.headers["Upstash-Telemetry-Sdk"]).toBe("sdk-a, sdk-b");
+    });
   });
 });

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -454,10 +454,9 @@ function merge(obj: Record<string, string>, key: string, value?: string): Record
     obj[key] = value;
     return obj;
   }
-  const values = obj[key].split(",");
-  if (!values.includes(value)) {
-    values.push(value);
-    obj[key] = values.join(",");
+  const values = obj[key].split(",").map((v) => v.trim());
+  if (!values.includes(value.trim())) {
+    obj[key] = [obj[key], value].join(",");
   }
   return obj;
 }


### PR DESCRIPTION
## Summary
Follow-up to #1440 (merged): review fixes for the telemetry dedup.

## Changes
- `merge` trims values when checking for duplicates, so a user-preset header like `"sdk-a, sdk-b"` still dedups `sdk-b`
- test: distinct versions of the same sdk are both kept
- test: whitespace around existing values does not defeat dedup

## Testing
- `bun test pkg/http.test.ts`: all pass