### PR TITLE
ci: poll npm for the ci version instead of a fixed sleep

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -655,6 +655,18 @@ jobs:
           npm pkg delete scripts.prepare
           npm publish --provenance --tag=ci --verbose
 
-      - name: Sleep for 10s
-        run: sleep 10s
+      - name: Wait for npm to serve the ci version
         shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION#v}"
+          for i in $(seq 1 36); do
+            if npm view "@upstash/redis@${VERSION}" version >/dev/null 2>&1; then
+              echo "@upstash/redis@${VERSION} is available on npm"
+              exit 0
+            fi
+            echo "waiting for @upstash/redis@${VERSION} to appear on npm ($i/36)..."
+            sleep 5
+          done
+          echo "::error::@upstash/redis@${VERSION} not visible on npm after 3 minutes"
+          exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -173,9 +173,7 @@ jobs:
       - name: Deploy
         run: |
           pnpm --dir=examples/vercel-functions-app-router add @upstash/redis@${{needs.release.outputs.version}}
-          # Pinned: vercel@59.x deploys the monorepo root without honouring the project's Root Directory
-          # ("No Next.js version detected"); 58.4.4 is the last version that deployed these examples.
-          DEPLOYMENT_URL=$(npx vercel@58.4.4 --token=${{ secrets.VERCEL_TOKEN }})
+          DEPLOYMENT_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }})
           echo "DEPLOYMENT_URL=${DEPLOYMENT_URL}" >> $GITHUB_ENV
         env:
           VERCEL_ORG_ID: ${{secrets.VERCEL_TEAM_ID}}
@@ -213,9 +211,7 @@ jobs:
       - name: Deploy
         run: |
           pnpm --dir=examples/vercel-functions-pages-router add @upstash/redis@${{needs.release.outputs.version}}
-          # Pinned: vercel@59.x deploys the monorepo root without honouring the project's Root Directory
-          # ("No Next.js version detected"); 58.4.4 is the last version that deployed these examples.
-          DEPLOYMENT_URL=$(npx vercel@58.4.4 --token=${{ secrets.VERCEL_TOKEN }})
+          DEPLOYMENT_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }})
           echo "DEPLOYMENT_URL=${DEPLOYMENT_URL}" >> $GITHUB_ENV
         env:
           VERCEL_ORG_ID: ${{secrets.VERCEL_TEAM_ID}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -240,15 +240,16 @@ jobs:
       - name: Install Dependencies
         run: bun install
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          # `deno deploy` ships with the Deno 2 CLI (deployctl / Deploy Classic were sunset on 2026-07-20)
+          deno-version: v2.x
 
       - name: Install @upstash/redis canary version
         run: sed -i 's;@upstash/redis@latest;@upstash/redis@${{needs.release.outputs.version}};' ./examples/deno/main.ts
 
       - name: Deploy
-        run: deno run -A https://deno.land/x/deploy@1.12.0/deployctl.ts deploy --project=upstash-redis ./main.ts
+        run: deno deploy --non-interactive --org upstash --app upstash-redis --prod
         working-directory: examples/deno
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
@@ -257,7 +258,7 @@ jobs:
         run: bun test main.test.ts
         working-directory: examples/deno
         env:
-          DEPLOYMENT_URL: https://upstash-redis-70jbfgxwz310.deno.dev
+          DEPLOYMENT_URL: https://upstash-redis.upstash.deno.net
 
   cloudflare-workers-local:
     needs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -173,7 +173,9 @@ jobs:
       - name: Deploy
         run: |
           pnpm --dir=examples/vercel-functions-app-router add @upstash/redis@${{needs.release.outputs.version}}
-          DEPLOYMENT_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }})
+          # Pinned: vercel@59.x deploys the monorepo root without honouring the project's Root Directory
+          # ("No Next.js version detected"); 58.4.4 is the last version that deployed these examples.
+          DEPLOYMENT_URL=$(npx vercel@58.4.4 --token=${{ secrets.VERCEL_TOKEN }})
           echo "DEPLOYMENT_URL=${DEPLOYMENT_URL}" >> $GITHUB_ENV
         env:
           VERCEL_ORG_ID: ${{secrets.VERCEL_TEAM_ID}}
@@ -211,7 +213,9 @@ jobs:
       - name: Deploy
         run: |
           pnpm --dir=examples/vercel-functions-pages-router add @upstash/redis@${{needs.release.outputs.version}}
-          DEPLOYMENT_URL=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }})
+          # Pinned: vercel@59.x deploys the monorepo root without honouring the project's Root Directory
+          # ("No Next.js version detected"); 58.4.4 is the last version that deployed these examples.
+          DEPLOYMENT_URL=$(npx vercel@58.4.4 --token=${{ secrets.VERCEL_TOKEN }})
           echo "DEPLOYMENT_URL=${DEPLOYMENT_URL}" >> $GITHUB_ENV
         env:
           VERCEL_ORG_ID: ${{secrets.VERCEL_TEAM_ID}}

--- a/examples/deno/deno.jsonc
+++ b/examples/deno/deno.jsonc
@@ -1,0 +1,7 @@
+{
+  "deploy": {
+    "org": "upstash",
+    "app": "upstash-redis"
+  }
+}
+

--- a/examples/deno/main.ts
+++ b/examples/deno/main.ts
@@ -1,7 +1,6 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { Redis } from "https://esm.sh/@upstash/redis@latest";
 
-serve(async (_req: Request) => {
+Deno.serve(async (_req: Request) => {
   const redis = Redis.fromEnv();
   const counter = await redis.incr("deno deploy counter");
 

--- a/examples/vercel-functions-app-router/vercel.json
+++ b/examples/vercel-functions-app-router/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --ignore-workspace --no-frozen-lockfile"
+}

--- a/examples/vercel-functions-pages-router/vercel.json
+++ b/examples/vercel-functions-pages-router/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --ignore-workspace --no-frozen-lockfile"
+}


### PR DESCRIPTION
DX-2954. Since 2026-07-31 the nightly *-deployed jobs fail with 'No version matching 0.0.0-ci.<sha>-<ts>' because the fixed sleep after 'npm publish --tag=ci' is no longer long enough for the registry to serve the new version. Replace the sleep with a poll (npm view, up to 3 minutes) so consumers only start once the version is actually resolvable.