### PR TITLE
DX-2960: send Upstash-Telemetry-Retry header with the attempt number (DX-2960)

### DIFF
--- a/.changeset/retry-telemetry-header.md
+++ b/.changeset/retry-telemetry-header.md
@@ -2,4 +2,4 @@
 "@upstash/redis": patch
 ---
 
-Send an `Upstash-Telemetry-Retry` header on retried requests so retry rates are visible in server-side telemetry
+Send an `Upstash-Telemetry-Retry` header with the attempt number (0 for the first try) so retry rates are visible in server-side telemetry

--- a/.changeset/retry-telemetry-header.md
+++ b/.changeset/retry-telemetry-header.md
@@ -2,4 +2,4 @@
 "@upstash/redis": patch
 ---
 
-Send an `Upstash-Telemetry-Retry` header with the attempt number (0 for the first try) so retry rates are visible in server-side telemetry
+Send an `Upstash-Telemetry-Retry` header with the retry count on retried requests so retry rates are visible in server-side telemetry

--- a/.changeset/retry-telemetry-header.md
+++ b/.changeset/retry-telemetry-header.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": patch
+---
+
+Send an `Upstash-Telemetry-Retry` header on retried requests so retry rates are visible in server-side telemetry

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ We collect the following:
 - SDK version
 - Platform (Deno, Cloudflare, Vercel)
 - Runtime version (node@18.x)
+- Retry attempt number of each request (to measure retry rates)
 
 You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
 to any truthy value.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ We collect the following:
 - SDK version
 - Platform (Deno, Cloudflare, Vercel)
 - Runtime version (node@18.x)
-- Retry attempt number of each request (to measure retry rates)
+- Retry count of retried requests (to measure retry rates)
 
 You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
 to any truthy value.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -127,6 +127,7 @@ We collect the following:
 - SDK version
 - Platform (Deno, Cloudflare, Vercel)
 - Runtime version (node@18.x)
+- Retry attempt number of each request (to measure retry rates)
 
 You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
 to any truthy value.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -127,7 +127,7 @@ We collect the following:
 - SDK version
 - Platform (Deno, Cloudflare, Vercel)
 - Runtime version (node@18.x)
-- Retry attempt number of each request (to measure retry rates)
+- Retry count of retried requests (to measure retry rates)
 
 You can opt out by setting the `UPSTASH_DISABLE_TELEMETRY` environment variable
 to any truthy value.

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -24,7 +24,8 @@ const withMockFetch = async (
     if (attempt++ < failures) {
       throw new Error("simulated network error");
     }
-    return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+    // Redis decodes base64 results by default, so return a valid base64 payload
+    return new Response(JSON.stringify({ result: btoa("OK") }), { status: 200 });
   }) as typeof fetch;
   try {
     await run(calls);
@@ -313,6 +314,12 @@ describe("http", () => {
         expect(calls[0]["Upstash-Telemetry-Retry"]).toBe("0");
         expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
         expect(calls[2]["Upstash-Telemetry-Retry"]).toBe("2");
+
+        // the attempt counter must not leak into the client's shared headers or the next request
+        expect(client.headers["Upstash-Telemetry-Retry"]).toBeUndefined();
+        await client.request({ body: ["get", "foo"] });
+        expect(calls).toHaveLength(4);
+        expect(calls[3]["Upstash-Telemetry-Retry"]).toBe("0");
       });
     });
 
@@ -329,6 +336,43 @@ describe("http", () => {
         expect(calls).toHaveLength(2);
         for (const headers of calls) {
           expect(headers["Upstash-Telemetry-Retry"]).toBeUndefined();
+        }
+      });
+    });
+
+    test("is sent by the Redis client together with the other telemetry headers", async () => {
+      await withMockFetch(1, async (calls) => {
+        const redis = new Redis({
+          url: SERVER_URL,
+          token: "test-token",
+          enableAutoPipelining: false,
+          retry: { retries: 2, backoff: () => 0 },
+        });
+
+        expect(await redis.get("foo")).toBe("OK");
+        expect(calls).toHaveLength(2);
+        expect(calls[0]["Upstash-Telemetry-Sdk"]).toStartWith("@upstash/redis@");
+        expect(calls[0]["Upstash-Telemetry-Retry"]).toBe("0");
+        expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
+      });
+    });
+
+    test("is not sent by the Redis client when enableTelemetry is false", async () => {
+      await withMockFetch(1, async (calls) => {
+        const redis = new Redis({
+          url: SERVER_URL,
+          token: "test-token",
+          enableTelemetry: false,
+          enableAutoPipelining: false,
+          retry: { retries: 2, backoff: () => 0 },
+        });
+
+        expect(await redis.get("foo")).toBe("OK");
+        expect(calls).toHaveLength(2);
+        for (const headers of calls) {
+          expect(Object.keys(headers).filter((h) => h.startsWith("Upstash-Telemetry-"))).toEqual(
+            []
+          );
         }
       });
     });

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -298,7 +298,7 @@ describe("http", () => {
   });
 
   describe("retry telemetry", () => {
-    test("sends Upstash-Telemetry-Retry only on retried attempts", async () => {
+    test("sends Upstash-Telemetry-Retry with the attempt number", async () => {
       await withMockFetch(2, async (calls) => {
         const client = new HttpClient({
           baseUrl: SERVER_URL,
@@ -310,7 +310,7 @@ describe("http", () => {
         const res = await client.request({ body: ["get", "foo"] });
         expect(res.result).toBe("OK");
         expect(calls).toHaveLength(3);
-        expect(calls[0]["Upstash-Telemetry-Retry"]).toBeUndefined();
+        expect(calls[0]["Upstash-Telemetry-Retry"]).toBe("0");
         expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
         expect(calls[2]["Upstash-Telemetry-Retry"]).toBe("2");
       });

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -299,7 +299,7 @@ describe("http", () => {
   });
 
   describe("retry telemetry", () => {
-    test("sends Upstash-Telemetry-Retry with the attempt number", async () => {
+    test("sends Upstash-Telemetry-Retry only on retried attempts", async () => {
       await withMockFetch(2, async (calls) => {
         const client = new HttpClient({
           baseUrl: SERVER_URL,
@@ -311,15 +311,15 @@ describe("http", () => {
         const res = await client.request({ body: ["get", "foo"] });
         expect(res.result).toBe("OK");
         expect(calls).toHaveLength(3);
-        expect(calls[0]["Upstash-Telemetry-Retry"]).toBe("0");
+        expect(calls[0]["Upstash-Telemetry-Retry"]).toBeUndefined();
         expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
         expect(calls[2]["Upstash-Telemetry-Retry"]).toBe("2");
 
-        // the attempt counter must not leak into the client's shared headers or the next request
+        // the retry counter must not leak into the client's shared headers or the next request
         expect(client.headers["Upstash-Telemetry-Retry"]).toBeUndefined();
         await client.request({ body: ["get", "foo"] });
         expect(calls).toHaveLength(4);
-        expect(calls[3]["Upstash-Telemetry-Retry"]).toBe("0");
+        expect(calls[3]["Upstash-Telemetry-Retry"]).toBeUndefined();
       });
     });
 
@@ -352,7 +352,8 @@ describe("http", () => {
         expect(await redis.get("foo")).toBe("OK");
         expect(calls).toHaveLength(2);
         expect(calls[0]["Upstash-Telemetry-Sdk"]).toStartWith("@upstash/redis@");
-        expect(calls[0]["Upstash-Telemetry-Retry"]).toBe("0");
+        expect(calls[0]["Upstash-Telemetry-Retry"]).toBeUndefined();
+        expect(calls[1]["Upstash-Telemetry-Sdk"]).toStartWith("@upstash/redis@");
         expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
       });
     });

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -7,6 +7,32 @@ import { HttpClient } from "./http";
 const MOCK_SERVER_PORT = 8080;
 const SERVER_URL = `http://localhost:${MOCK_SERVER_PORT}`;
 
+/**
+ * Replaces global fetch with one that throws `failures` times before succeeding and
+ * records the headers of every attempt.
+ */
+const withMockFetch = async (
+  failures: number,
+  run: (calls: Record<string, string>[]) => Promise<void>
+) => {
+  const calls: Record<string, string>[] = [];
+  const originalFetch = globalThis.fetch;
+  let attempt = 0;
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    // copy headers since the same object is mutated between attempts
+    calls.push({ ...(init?.headers as Record<string, string>) });
+    if (attempt++ < failures) {
+      throw new Error("simulated network error");
+    }
+    return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+  }) as typeof fetch;
+  try {
+    await run(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+};
+
 describe("http", () => {
   test("should terminate after sleeping 5 times", async () => {
     // init a cient which will always get errors
@@ -268,6 +294,43 @@ describe("http", () => {
       client.mergeTelemetry({ sdk: "sdk-b" });
 
       expect(client.headers["Upstash-Telemetry-Sdk"]).toBe("sdk-a, sdk-b");
+    });
+  });
+
+  describe("retry telemetry", () => {
+    test("sends Upstash-Telemetry-Retry only on retried attempts", async () => {
+      await withMockFetch(2, async (calls) => {
+        const client = new HttpClient({
+          baseUrl: SERVER_URL,
+          headers: { authorization: "Bearer test-token" },
+          retry: { retries: 3, backoff: () => 0 },
+        });
+        client.mergeTelemetry({ sdk: "@upstash/redis@1.0.0" });
+
+        const res = await client.request({ body: ["get", "foo"] });
+        expect(res.result).toBe("OK");
+        expect(calls).toHaveLength(3);
+        expect(calls[0]["Upstash-Telemetry-Retry"]).toBeUndefined();
+        expect(calls[1]["Upstash-Telemetry-Retry"]).toBe("1");
+        expect(calls[2]["Upstash-Telemetry-Retry"]).toBe("2");
+      });
+    });
+
+    test("does not send Upstash-Telemetry-Retry when telemetry is disabled", async () => {
+      await withMockFetch(1, async (calls) => {
+        const client = new HttpClient({
+          baseUrl: SERVER_URL,
+          headers: { authorization: "Bearer test-token" },
+          retry: { retries: 2, backoff: () => 0 },
+        });
+
+        const res = await client.request({ body: ["get", "foo"] });
+        expect(res.result).toBe("OK");
+        expect(calls).toHaveLength(2);
+        for (const headers of calls) {
+          expect(headers["Upstash-Telemetry-Retry"]).toBeUndefined();
+        }
+      });
     });
   });
 });

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -151,6 +151,7 @@ export class HttpClient implements Requester {
   public readYourWrites: boolean;
   public upstashSyncToken = "";
   private hasCredentials: boolean;
+  private telemetryEnabled = false;
 
   public readonly retry: {
     attempts: number;
@@ -210,6 +211,7 @@ export class HttpClient implements Requester {
   }
 
   public mergeTelemetry(telemetry: Telemetry): void {
+    this.telemetryEnabled = true;
     this.headers = merge(this.headers, "Upstash-Telemetry-Runtime", telemetry.runtime);
     this.headers = merge(this.headers, "Upstash-Telemetry-Platform", telemetry.platform);
     this.headers = merge(this.headers, "Upstash-Telemetry-Sdk", telemetry.sdk);
@@ -256,6 +258,10 @@ export class HttpClient implements Requester {
     let res: Response | null = null;
     let error: Error | null = null;
     for (let i = 0; i <= this.retry.attempts; i++) {
+      if (i > 0 && this.telemetryEnabled) {
+        // Mark retried attempts so the server can track how often clients retry.
+        requestHeaders["Upstash-Telemetry-Retry"] = String(i);
+      }
       try {
         res = await fetch(requestUrl, requestOptions);
         break;

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -151,6 +151,7 @@ export class HttpClient implements Requester {
   public readYourWrites: boolean;
   public upstashSyncToken = "";
   private hasCredentials: boolean;
+  /** Set once `mergeTelemetry` has been called, i.e. telemetry is enabled on the Redis client. */
   private telemetryEnabled = false;
 
   public readonly retry: {

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -259,8 +259,8 @@ export class HttpClient implements Requester {
     let res: Response | null = null;
     let error: Error | null = null;
     for (let i = 0; i <= this.retry.attempts; i++) {
-      if (this.telemetryEnabled) {
-        // Attempt number (0 = first try) so the server can track how often clients retry.
+      if (i > 0 && this.telemetryEnabled) {
+        // Mark retried attempts with the retry count so the server can track how often clients retry.
         requestHeaders["Upstash-Telemetry-Retry"] = String(i);
       }
       try {

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -151,8 +151,6 @@ export class HttpClient implements Requester {
   public readYourWrites: boolean;
   public upstashSyncToken = "";
   private hasCredentials: boolean;
-  /** Set once `mergeTelemetry` has been called, i.e. telemetry is enabled on the Redis client. */
-  private telemetryEnabled = false;
 
   public readonly retry: {
     attempts: number;
@@ -212,7 +210,6 @@ export class HttpClient implements Requester {
   }
 
   public mergeTelemetry(telemetry: Telemetry): void {
-    this.telemetryEnabled = true;
     this.headers = merge(this.headers, "Upstash-Telemetry-Runtime", telemetry.runtime);
     this.headers = merge(this.headers, "Upstash-Telemetry-Platform", telemetry.platform);
     this.headers = merge(this.headers, "Upstash-Telemetry-Sdk", telemetry.sdk);
@@ -259,7 +256,7 @@ export class HttpClient implements Requester {
     let res: Response | null = null;
     let error: Error | null = null;
     for (let i = 0; i <= this.retry.attempts; i++) {
-      if (i > 0 && this.telemetryEnabled) {
+      if (i > 0 && requestHeaders["Upstash-Telemetry-Sdk"]) {
         // Mark retried attempts with the retry count so the server can track how often clients retry.
         requestHeaders["Upstash-Telemetry-Retry"] = String(i);
       }

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -258,8 +258,8 @@ export class HttpClient implements Requester {
     let res: Response | null = null;
     let error: Error | null = null;
     for (let i = 0; i <= this.retry.attempts; i++) {
-      if (i > 0 && this.telemetryEnabled) {
-        // Mark retried attempts so the server can track how often clients retry.
+      if (this.telemetryEnabled) {
+        // Attempt number (0 = first try) so the server can track how often clients retry.
         requestHeaders["Upstash-Telemetry-Retry"] = String(i);
       }
       try {


### PR DESCRIPTION
## Summary

Sends an `Upstash-Telemetry-Retry: <n>` header on retried attempts when telemetry is enabled — `1`, `2`, … — so the server can see how often clients retry requests.

The initial attempt does not include this header. Existing SDK telemetry remains present on every attempt and can be used as the overall request-attempt count.

## Why

The SDK retries silently on network errors (no response received). Today there is no way to tell from server-side metrics whether a database is seeing a wave of client retries. redis-server already tracks every `Upstash-Telemetry-*` header generically in the per-database `Clients.RestTelemetry` counters (`core/tcp/telemetry.go`), so this header lands there with no server change; the exporter side is added in the corresponding upstash-cloud PR.

## Changes

- `http.ts`: the retry loop sets `Upstash-Telemetry-Retry` to the attempt number on retried attempts when the request contains the SDK telemetry header.
- `http.test.ts`: tests with a mocked `fetch` that fails N times assert the header is absent on the initial attempt, is `"1"`, `"2"`, … on retries, does not leak between requests, and is never sent when telemetry is disabled.
- README telemetry disclosures and patch changeset.

## Design notes

- Sent only on retried attempts when telemetry is on; nothing is sent on the initial attempt or when telemetry is disabled.
- The value is the raw attempt number. redis-server caps distinct values per telemetry key at 50, so a very large user-configured retry count simply stops being counted beyond that.
- Resulting Prometheus series: `upstash_user_telemetry{type="retry_1"}`, `retry_2`, … .
