### PR TITLE
DX-2995: fix read-your-writes sending a stale upstash-sync-token

### DIFF
--- a/.changeset/ryw-sync-token-ordering.md
+++ b/.changeset/ryw-sync-token-ordering.md
@@ -1,0 +1,19 @@
+---
+"@upstash/redis": patch
+---
+
+Fix read-your-writes sending a stale `upstash-sync-token`
+
+A read issued straight after a write travelled with the token from _before_ that
+write, so the server was under no obligation to serve the write and
+`readYourWrites` silently did not hold.
+
+`HttpClient.request()` snapshotted the outgoing headers with
+`mergeHeaders(this.headers, ...)` and only afterwards wrote the freshest token into
+`this.headers`, so the token learned from response N first shipped with request
+N+2. The assignment now happens before the merge.
+
+This regressed in **1.34.5**. In 1.34.0–1.34.4 the request options held
+`headers: this.headers` by reference, so the late write was still picked up before
+`fetch`; 1.34.5 introduced per-request header merging, which turned that reference
+into a copy without moving the assignment.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -249,7 +249,10 @@ jobs:
         run: sed -i 's;@upstash/redis@latest;@upstash/redis@${{needs.release.outputs.version}};' ./examples/deno/main.ts
 
       - name: Deploy
-        run: deno deploy --non-interactive --org upstash --app upstash-redis --prod
+        # The bundled `deno deploy` subcommand duplicates every flag it forwards to the
+        # deploy CLI, so it always exits 2 with `Option "--org" can only occur once`.
+        # Invoke the CLI from JSR directly until that wrapper is fixed.
+        run: deno run -A jsr:@deno/deploy --non-interactive --org upstash --app upstash-redis --prod
         working-directory: examples/deno
         env:
           DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -216,6 +216,17 @@ export class HttpClient implements Requester {
   }
 
   public async request<TResult>(req: UpstashRequest): Promise<UpstashResponse<TResult>> {
+    /**
+     * We've received a new `upstash-sync-token` in the previous response. We use it in the next
+     * request to observe the effects of previous requests.
+     *
+     * This has to happen *before* the headers are merged below: `mergeHeaders` copies
+     * `this.headers`, so writing the token afterwards would only reach the request after this one.
+     */
+    if (this.readYourWrites) {
+      this.headers["upstash-sync-token"] = this.upstashSyncToken;
+    }
+
     const requestHeaders = mergeHeaders(this.headers, req.headers ?? {});
     const requestUrl = [this.baseUrl, ...(req.path ?? [])].join("/");
     const isEventStream = requestHeaders.Accept === "text/event-stream";
@@ -243,14 +254,6 @@ export class HttpClient implements Requester {
         "[Upstash Redis] Redis client was initialized without url or token." +
           " Failed to execute command."
       );
-    }
-
-    /**
-     * We've recieved a new `upstash-sync-token` in the previous response. We use it in the next request to observe the effects of previous requests.
-     */
-    if (this.readYourWrites) {
-      const newHeader = this.upstashSyncToken;
-      this.headers["upstash-sync-token"] = newHeader;
     }
 
     let res: Response | null = null;

--- a/packages/redis/pkg/read-your-writes.test.ts
+++ b/packages/redis/pkg/read-your-writes.test.ts
@@ -3,11 +3,12 @@ import { keygen, newHttpClient } from "./test-utils";
 import { afterAll, describe, expect, test } from "bun:test";
 
 import { Redis as PublicRedis } from "../platforms/nodejs";
+import { GetCommand } from "./commands/get";
 import { SetCommand } from "./commands/set";
 import { Redis } from "./redis";
 
 const client = newHttpClient();
-const { cleanup } = keygen();
+const { newKey, cleanup } = keygen();
 afterAll(cleanup);
 describe("Read Your Writes Feature", () => {
   test("successfully retrieves Upstash-Sync-Token in the response header and updates local state", async () => {
@@ -17,6 +18,39 @@ describe("Read Your Writes Feature", () => {
     await new SetCommand(["key", "value"]).exec(client);
 
     expect(updatedSync).not.toEqual(initialSync);
+  });
+
+  /**
+   * Every other test here asserts the token the client *stored* after a response. None of them
+   * asserted the token it actually *sends*, which is the half read-your-writes depends on — so this
+   * captures the outgoing `upstash-sync-token` header instead.
+   *
+   * `request()` snapshots the outgoing headers with `mergeHeaders(this.headers, ...)` and only then
+   * writes the freshest token into `this.headers`, so the write lands one request too late: the read
+   * that follows a write travels without the token that proves the write happened.
+   */
+  test("sends the token from the write on the request that follows it", async () => {
+    const key = newKey();
+    const sentTokens: (string | null)[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: Parameters<typeof realFetch>[0], init?: RequestInit) => {
+      sentTokens.push(new Headers(init?.headers).get("upstash-sync-token"));
+      return realFetch(input, init);
+    }) as typeof globalThis.fetch;
+
+    try {
+      await new SetCommand([key, "value"]).exec(client);
+      // The token the server handed back for the write — the position a subsequent read must be
+      // able to observe.
+      const tokenFromWrite = client.upstashSyncToken;
+
+      await new GetCommand([key]).exec(client);
+
+      expect(sentTokens).toHaveLength(2);
+      expect(sentTokens[1]).toBe(tokenFromWrite);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 
   test("succesfully updates sync state with pipeline", async () => {


### PR DESCRIPTION
Summary

readYourWrites has been sending the wrong upstash-sync-token since 1.34.5 (2025-03-06). A read issued right after a write travels with the token from before that write, so the server is under no obligation to serve the write — read-your-writes silently does not hold.

HttpClient.request() snapshots the outgoing headers and only afterwards writes the freshest token into this.headers:

```
const requestHeaders = mergeHeaders(this.headers, req.headers ?? {}); // snapshot
const requestOptions = { headers: requestHeaders, ... };
...
if (this.readYourWrites) {
  this.headers["upstash-sync-token"] = this.upstashSyncToken;        // lands too late
}
await fetch(requestUrl, requestOptions);                              // sends the snapshot
```

The token learned from response N only ships with request N+2.

This was correct in 1.34.0–1.34.4, where the options held headers: this.headers by reference, so the mutation was picked up before fetch. 1.34.5 introduced per-request mergeHeaders, which turned that reference into a copy without moving the assignment — the line didn't change, the assumption underneath it did.

This PR is the failing test only. The fix follows in a second commit so the regression is visible in CI first.

Changes

- packages/redis/pkg/read-your-writes.test.ts: assert the upstash-sync-token header the client actually sends, by capturing fetch. Every existing test in this file asserts client.upstashSyncToken — the value stored after a response — which is why the bug survived: the sending half was never covered.

Testing

Fails on main: expected 16gdr (the token the SET returned), received 16gdq (the token from before it). 8 pass, 1 fail.

Note for review

A second, separate defect in the same area, not addressed here: this.upstashSyncToken = headers.get("upstash-sync-token") ?? "" assigns unconditionally, so a read's 0 token overwrites a real write token. Worth deciding separately — may depend on server semantics for 0.