### PR TITLE
fix(redis): handle authorization headers case-insensitively

### DIFF
--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -377,5 +377,16 @@ describe("http", () => {
         }
       });
     });
+
+    test("should handle missing or capitalized Authorization header gracefully", () => {
+      const client1 = new HttpClient({ baseUrl: "https://example.com", headers: {} });
+      expect(client1.baseUrl).toBe("https://example.com");
+
+      const client2 = new HttpClient({
+        baseUrl: "https://example.com",
+        headers: { Authorization: "Bearer test-token" },
+      });
+      expect(client2.baseUrl).toBe("https://example.com");
+    });
   });
 });

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -378,15 +378,32 @@ describe("http", () => {
       });
     });
 
-    test("should handle missing or capitalized Authorization header gracefully", () => {
-      const client1 = new HttpClient({ baseUrl: "https://example.com", headers: {} });
-      expect(client1.baseUrl).toBe("https://example.com");
+    test("should handle authorization header variations and credential state", () => {
+      // 1. Missing Authorization header should not throw and marks hasCredentials false
+      const clientNoAuth = new HttpClient({ baseUrl: "https://example.com", headers: {} });
+      expect(clientNoAuth.baseUrl).toBe("https://example.com");
+      expect((clientNoAuth as any).hasCredentials).toBe(false);
 
-      const client2 = new HttpClient({
+      // 2. Lowercase authorization header with Bearer token marks hasCredentials true
+      const clientLower = new HttpClient({
         baseUrl: "https://example.com",
-        headers: { Authorization: "Bearer test-token" },
+        headers: { authorization: "Bearer token-123" },
       });
-      expect(client2.baseUrl).toBe("https://example.com");
+      expect((clientLower as any).hasCredentials).toBe(true);
+
+      // 3. Capitalized Authorization header with Bearer token marks hasCredentials true
+      const clientUpper = new HttpClient({
+        baseUrl: "https://example.com",
+        headers: { Authorization: "Bearer token-123" },
+      });
+      expect((clientUpper as any).hasCredentials).toBe(true);
+
+      // 4. Absence of token does not mark client authenticated
+      const clientEmptyToken = new HttpClient({
+        baseUrl: "https://example.com",
+        headers: { authorization: "Bearer " },
+      });
+      expect((clientEmptyToken as any).hasCredentials).toBe(false);
     });
   });
 });

--- a/packages/redis/pkg/http.test.ts
+++ b/packages/redis/pkg/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn } from "bun:test";
 import { Redis } from "../platforms/nodejs";
 import { serve } from "bun";
 import { UpstashJSONParseError } from "./error";
@@ -378,32 +378,60 @@ describe("http", () => {
       });
     });
 
-    test("should handle authorization header variations and credential state", () => {
-      // 1. Missing Authorization header should not throw and marks hasCredentials false
-      const clientNoAuth = new HttpClient({ baseUrl: "https://example.com", headers: {} });
-      expect(clientNoAuth.baseUrl).toBe("https://example.com");
-      expect((clientNoAuth as any).hasCredentials).toBe(false);
+    test("should handle authorization header casing variations based on observable warning behavior", async () => {
+      await withMockFetch(1, async () => {
+        const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
-      // 2. Lowercase authorization header with Bearer token marks hasCredentials true
-      const clientLower = new HttpClient({
-        baseUrl: "https://example.com",
-        headers: { authorization: "Bearer token-123" },
-      });
-      expect((clientLower as any).hasCredentials).toBe(true);
+        try {
+          // 1. Missing Authorization header: constructor does not throw, request emits missing-credentials warning
+          const clientNoAuth = new HttpClient({ baseUrl: "https://example.com", headers: {} });
+          expect(clientNoAuth.baseUrl).toBe("https://example.com");
+          await clientNoAuth.request({ body: ["GET", "key"] });
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("[Upstash Redis] Redis client was initialized without url or token.")
+          );
+          warnSpy.mockClear();
 
-      // 3. Capitalized Authorization header with Bearer token marks hasCredentials true
-      const clientUpper = new HttpClient({
-        baseUrl: "https://example.com",
-        headers: { Authorization: "Bearer token-123" },
-      });
-      expect((clientUpper as any).hasCredentials).toBe(true);
+          // 2. Lowercase authorization: valid Bearer token, request does NOT emit missing-credentials warning
+          const clientLower = new HttpClient({
+            baseUrl: "https://example.com",
+            headers: { authorization: "Bearer token-123" },
+          });
+          await clientLower.request({ body: ["GET", "key"] });
+          expect(warnSpy).not.toHaveBeenCalled();
+          warnSpy.mockClear();
 
-      // 4. Absence of token does not mark client authenticated
-      const clientEmptyToken = new HttpClient({
-        baseUrl: "https://example.com",
-        headers: { authorization: "Bearer " },
+          // 3. Capitalized Authorization: valid Bearer token, request does NOT emit warning
+          const clientUpper = new HttpClient({
+            baseUrl: "https://example.com",
+            headers: { Authorization: "Bearer token-123" },
+          });
+          await clientUpper.request({ body: ["GET", "key"] });
+          expect(warnSpy).not.toHaveBeenCalled();
+          warnSpy.mockClear();
+
+          // 4. Mixed-case spelling (aUtHoRiZaTiOn): valid Bearer token, request does NOT emit warning
+          const clientMixed = new HttpClient({
+            baseUrl: "https://example.com",
+            headers: { aUtHoRiZaTiOn: "Bearer token-123" },
+          });
+          await clientMixed.request({ body: ["GET", "key"] });
+          expect(warnSpy).not.toHaveBeenCalled();
+          warnSpy.mockClear();
+
+          // 5. Empty Bearer token: treated as missing credentials, request DOES emit warning
+          const clientEmptyToken = new HttpClient({
+            baseUrl: "https://example.com",
+            headers: { authorization: "Bearer " },
+          });
+          await clientEmptyToken.request({ body: ["GET", "key"] });
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("[Upstash Redis] Redis client was initialized without url or token.")
+          );
+        } finally {
+          warnSpy.mockRestore();
+        }
       });
-      expect((clientEmptyToken as any).hasCredentials).toBe(false);
     });
   });
 });

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -191,7 +191,8 @@ export class HttpClient implements Requester {
       ...config.headers,
     };
 
-    this.hasCredentials = Boolean(this.baseUrl && this.headers.authorization.split(" ")[1]);
+    const authHeader = this.headers.authorization ?? this.headers.Authorization ?? "";
+    this.hasCredentials = Boolean(this.baseUrl && authHeader.split(" ")[1]);
 
     if (this.options.responseEncoding === "base64") {
       this.headers["Upstash-Encoding"] = "base64";

--- a/packages/redis/pkg/http.ts
+++ b/packages/redis/pkg/http.ts
@@ -191,7 +191,10 @@ export class HttpClient implements Requester {
       ...config.headers,
     };
 
-    const authHeader = this.headers.authorization ?? this.headers.Authorization ?? "";
+    const authKey = Object.keys(this.headers).find(
+      (key) => key.toLowerCase() === "authorization"
+    );
+    const authHeader = authKey ? this.headers[authKey] : "";
     this.hasCredentials = Boolean(this.baseUrl && authHeader.split(" ")[1]);
 
     if (this.options.responseEncoding === "base64") {


### PR DESCRIPTION
This PR prevents credential detection from failing or throwing when the Authorization header is missing or uses non-lowercase casing. Header lookup is now case-insensitive, with regression coverage based on observable request warning behavior.