### PR TITLE
DX-3010: support search indexes over redis streams

### DIFF
--- a/.changeset/search-stream-indexes.md
+++ b/.changeset/search-stream-indexes.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": minor
+---
+
+Support search indexes over Redis streams: `redis.search.createIndex({ dataType: "stream", stream: "events", schema })` indexes every entry of the stream as a document keyed by its entry ID. `describe()` reports `dataType: "stream"` with the stream key in `prefixes`.

--- a/packages/redis/pkg/commands/search/command-builder.test.ts
+++ b/packages/redis/pkg/commands/search/command-builder.test.ts
@@ -543,6 +543,68 @@ describe("buildCreateIndexCommand", () => {
     });
   });
 
+  describe("stream index", () => {
+    test("builds stream index command with the stream key instead of PREFIX", () => {
+      const schema = s.object({
+        message: s.string(),
+        severity: s.number("U64"),
+        service: s.keyword(),
+      });
+
+      const command = buildCreateIndexCommand({
+        name: "event-search",
+        schema,
+        dataType: "stream",
+        stream: "events",
+      });
+
+      expect(command).toEqual([
+        "SEARCH.CREATE",
+        "event-search",
+        "ON",
+        "STREAM",
+        "events",
+        "SCHEMA",
+        "message",
+        "TEXT",
+        "severity",
+        "U64",
+        "FAST",
+        "service",
+        "KEYWORD",
+      ]);
+    });
+
+    test("builds stream index command with options", () => {
+      const command = buildCreateIndexCommand({
+        name: "event-search",
+        schema: s.object({ description: s.string().from("message") }),
+        dataType: "stream",
+        stream: "events",
+        language: "turkish",
+        skipInitialScan: true,
+        existsOk: true,
+      });
+
+      expect(command).toEqual([
+        "SEARCH.CREATE",
+        "event-search",
+        "SKIPINITIALSCAN",
+        "EXISTSOK",
+        "ON",
+        "STREAM",
+        "events",
+        "LANGUAGE",
+        "turkish",
+        "SCHEMA",
+        "description",
+        "TEXT",
+        "FROM",
+        "message",
+      ]);
+    });
+  });
+
   describe("string/JSON index", () => {
     test("builds nested string index command", () => {
       const schema = s.object({

--- a/packages/redis/pkg/commands/search/command-builder.ts
+++ b/packages/redis/pkg/commands/search/command-builder.ts
@@ -108,18 +108,27 @@ function buildScoreFuncField(
 export function buildCreateIndexCommand<TSchema extends NestedIndexSchema | FlatIndexSchema>(
   params: CreateIndexParameters<TSchema>
 ): string[] {
-  const { name, schema, dataType, prefix, language, skipInitialScan, existsOk } = params;
-  const prefixArray = Array.isArray(prefix) ? prefix : [prefix];
+  const { name, schema, dataType, language, skipInitialScan, existsOk } = params;
+
+  let source: string[];
+  if (params.dataType === "stream") {
+    source = ["ON", "STREAM", params.stream];
+  } else {
+    const prefixArray = Array.isArray(params.prefix) ? params.prefix : [params.prefix];
+    source = [
+      "ON",
+      dataType.toUpperCase(),
+      "PREFIX",
+      prefixArray.length.toString(),
+      ...prefixArray,
+    ];
+  }
 
   const payload: string[] = [
     name,
     ...(skipInitialScan ? ["SKIPINITIALSCAN"] : []),
     ...(existsOk ? ["EXISTSOK"] : []),
-    "ON",
-    dataType.toUpperCase(),
-    "PREFIX",
-    prefixArray.length.toString(),
-    ...prefixArray,
+    ...source,
     ...(language ? ["LANGUAGE", language] : []),
     "SCHEMA",
   ];

--- a/packages/redis/pkg/commands/search/search-stream.test.ts
+++ b/packages/redis/pkg/commands/search/search-stream.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { keygen, newHttpClient, randomID } from "../../test-utils";
+import { XAddCommand } from "../xadd";
+import { XDelCommand } from "../xdel";
+import { Redis } from "../../redis";
+import { createIndex, initIndex } from "./search";
+import { s } from "./schema-builder";
+
+const client = newHttpClient();
+const { newKey, cleanup } = keygen();
+
+// Each test creates at most one index at a time and drops it afterwards.
+const createdIndexes: string[] = [];
+afterEach(async () => {
+  for (const name of createdIndexes) {
+    try {
+      await initIndex(client, { name }).drop();
+    } catch {
+      // already dropped
+    }
+  }
+  createdIndexes.length = 0;
+  await cleanup();
+});
+
+const schema = s.object({
+  message: s.string(),
+  severity: s.number("U64"),
+  service: s.keyword(),
+});
+
+// Never called: these only exist so tsc verifies the stream-index parameter types.
+const createStreamIndexWithPrefix = () =>
+  createIndex(
+    client,
+    // @ts-expect-error prefix is not allowed for stream indexes
+    { name: "never", schema, dataType: "stream", stream: "events", prefix: "events:" }
+  );
+const createStreamIndexWithoutStream = () =>
+  createIndex(
+    client,
+    // @ts-expect-error stream is required for stream indexes
+    { name: "never", schema, dataType: "stream" }
+  );
+
+function newIndexName() {
+  const name = `test-stream-${randomID().slice(0, 8)}`;
+  createdIndexes.push(name);
+  return name;
+}
+
+describe("stream search index", () => {
+  test("indexes stream entries and returns entry IDs as keys", async () => {
+    const stream = newKey();
+    const index = await createIndex(client, {
+      name: newIndexName(),
+      schema,
+      dataType: "stream",
+      stream,
+    });
+
+    await new XAddCommand([
+      stream,
+      "1-0",
+      { message: "Payment authorization failed", severity: 4, service: "checkout" },
+    ]).exec(client);
+    await new XAddCommand([
+      stream,
+      "2-0",
+      { message: "Order completed", severity: 1, service: "checkout" },
+    ]).exec(client);
+    await index.waitIndexing();
+
+    const results = await index.query({
+      filter: { message: "authorization", severity: { $gte: 3 } },
+    });
+    expect(results).toEqual([
+      expect.objectContaining({
+        key: "1-0",
+        data: { message: "Payment authorization failed", severity: 4, service: "checkout" },
+      }),
+    ]);
+
+    const selected = await index.query({
+      filter: { service: "checkout" },
+      orderBy: { severity: "ASC" },
+      select: { message: true },
+    });
+    expect(selected.map((r) => [r.key, r.data])).toEqual([
+      ["2-0", { message: "Order completed" }],
+      ["1-0", { message: "Payment authorization failed" }],
+    ]);
+
+    expect(await index.count({ filter: { service: "checkout" } })).toEqual({ count: 2 });
+  });
+
+  test("describe reports the stream data type and key", async () => {
+    const stream = newKey();
+    const name = newIndexName();
+    const index = await createIndex(client, { name, schema, dataType: "stream", stream });
+
+    const description = await index.describe();
+    expect(description?.name).toBe(name);
+    expect(description?.dataType).toBe("stream");
+    expect(description?.prefixes).toEqual([stream]);
+    expect(description?.schema).toEqual({
+      message: { type: "TEXT" },
+      severity: { type: "U64", fast: true },
+      service: { type: "KEYWORD" },
+    });
+  });
+
+  test("removes documents for deleted entries", async () => {
+    const stream = newKey();
+    const index = await createIndex(client, {
+      name: newIndexName(),
+      schema,
+      dataType: "stream",
+      stream,
+    });
+
+    const id = await new XAddCommand([
+      stream,
+      "*",
+      { message: "to be deleted", severity: 2, service: "api" },
+    ]).exec(client);
+    await index.waitIndexing();
+    expect(await index.count({ filter: { service: "api" } })).toEqual({ count: 1 });
+
+    await new XDelCommand([stream, id as string]).exec(client);
+    await index.waitIndexing();
+    expect(await index.count({ filter: { service: "api" } })).toEqual({ count: 0 });
+  });
+
+  test("skipInitialScan ignores entries that already exist", async () => {
+    const stream = newKey();
+    await new XAddCommand([stream, "1-0", { message: "old", severity: 1, service: "a" }]).exec(
+      client
+    );
+
+    const index = await createIndex(client, {
+      name: newIndexName(),
+      schema,
+      dataType: "stream",
+      stream,
+      skipInitialScan: true,
+    });
+    await new XAddCommand([stream, "2-0", { message: "new", severity: 1, service: "a" }]).exec(
+      client
+    );
+    await index.waitIndexing();
+
+    const results = await index.query({ filter: { service: "a" } });
+    expect(results.map((r) => r.key)).toEqual(["2-0"]);
+  });
+
+  test("is available through redis.search.createIndex", async () => {
+    const redis = new Redis(client);
+    const stream = newKey();
+    const index = await redis.search.createIndex({
+      name: newIndexName(),
+      schema,
+      dataType: "stream",
+      stream,
+      existsOk: true,
+    });
+
+    await redis.xadd(stream, "*", { message: "hello", severity: 1, service: "web" });
+    await index.waitIndexing();
+    expect(await index.count({ filter: { service: "web" } })).toEqual({ count: 1 });
+  });
+
+  test("types: stream indexes take a stream key instead of a prefix", () => {
+    // compile-time checks only, see createStreamIndexWithPrefix / createStreamIndexWithoutStream
+    expect(typeof createStreamIndexWithPrefix).toBe("function");
+    expect(typeof createStreamIndexWithoutStream).toBe("function");
+  });
+});

--- a/packages/redis/pkg/commands/search/search.ts
+++ b/packages/redis/pkg/commands/search/search.ts
@@ -25,14 +25,40 @@ import {
 
 export type CreateIndexParameters<TSchema extends NestedIndexSchema | FlatIndexSchema> = {
   name: string;
-  prefix: string | string[];
   language?: Language;
   skipInitialScan?: boolean;
   existsOk?: boolean;
 } & (
-  | { dataType: "string"; schema: TSchema extends NestedIndexSchema ? TSchema : never }
-  | { dataType: "json"; schema: TSchema extends NestedIndexSchema ? TSchema : never }
-  | { dataType: "hash"; schema: TSchema extends FlatIndexSchema ? TSchema : never }
+  | {
+      dataType: "string";
+      prefix: string | string[];
+      schema: TSchema extends NestedIndexSchema ? TSchema : never;
+    }
+  | {
+      dataType: "json";
+      prefix: string | string[];
+      schema: TSchema extends NestedIndexSchema ? TSchema : never;
+    }
+  | {
+      dataType: "hash";
+      prefix: string | string[];
+      schema: TSchema extends FlatIndexSchema ? TSchema : never;
+    }
+  | {
+      /**
+       * Index the entries of a single Redis stream. Each entry becomes a document whose key is
+       * the entry ID and whose fields are the entry's fields.
+       *
+       * @see https://upstash.com/docs/redis/search/streams
+       */
+      dataType: "stream";
+      /**
+       * Exact key of the stream to index. The stream does not need to exist yet.
+       */
+      stream: string;
+      prefix?: never;
+      schema: TSchema extends FlatIndexSchema ? TSchema : never;
+    }
 );
 
 export type InitIndexParameters<TSchema extends NestedIndexSchema | FlatIndexSchema> = {

--- a/packages/redis/pkg/commands/search/types.ts
+++ b/packages/redis/pkg/commands/search/types.ts
@@ -589,7 +589,10 @@ export type DescribeFieldInfo = {
 
 export type IndexDescription<TSchema extends NestedIndexSchema | FlatIndexSchema> = {
   name: string;
-  dataType: "hash" | "string" | "json";
+  dataType: "hash" | "string" | "json" | "stream";
+  /**
+   * Key prefixes tracked by the index. For a stream index, this holds the single stream key.
+   */
   prefixes: string[];
   language?: Language;
   schema: IsDefaultSchema<TSchema> extends true

--- a/packages/redis/pkg/commands/search/utils.ts
+++ b/packages/redis/pkg/commands/search/utils.ts
@@ -128,10 +128,9 @@ export function deserializeDescribeResponse<TSchema extends NestedIndexSchema | 
         break;
       }
       case "type": {
-        description["dataType"] = (rawResponse[i + 1] as string).toLowerCase() as
-          | "hash"
-          | "string"
-          | "json";
+        description["dataType"] = (
+          rawResponse[i + 1] as string
+        ).toLowerCase() as IndexDescription<TSchema>["dataType"];
         break;
       }
       case "prefixes": {

--- a/skills/search/commands/index-management.md
+++ b/skills/search/commands/index-management.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Create, inspect, and drop search indexes. Wait for indexing to complete after data changes. Indexes automatically track Redis keys matching a specified prefix.
+Create, inspect, and drop search indexes. Wait for indexing to complete after data changes. Indexes automatically track Redis keys matching a specified prefix, or the entries of a single stream.
 
 ## Good For
 
@@ -47,6 +47,46 @@ const hashIndex = await redis.search.createIndex({
 });
 ```
 
+### Create a Stream Index
+
+A stream index is bound to one exact stream key (no `prefix`). Every entry added with `XADD` becomes a document whose `key` is the entry ID. The stream does not need to exist yet, and entries removed with `XDEL`/`XTRIM` (or by deleting the stream) leave the index too.
+
+```typescript
+const events = await redis.search.createIndex({
+  name: "event-search",
+  dataType: "stream",
+  stream: "events", // exact stream key, not a prefix
+  schema: s.object({
+    message: s.string(),
+    service: s.keyword(),
+    severity: s.number("U64"),
+    occurredAt: s.date().fast(),
+  }),
+});
+
+await redis.xadd("events", "*", {
+  message: "Payment authorization failed",
+  service: "checkout",
+  severity: 4,
+  occurredAt: new Date().toISOString(),
+});
+await events.waitIndexing();
+
+const hits = await events.query({
+  filter: { message: "authorization", severity: { $gte: 3 } },
+});
+// [{ key: "1757000000000-0", score: 0.5, data: { message: "...", service: "checkout", severity: 4, ... } }]
+
+// Read the full original entry by its ID
+const [entry] = await redis.xrange("events", hits[0].key, hits[0].key);
+```
+
+Notes:
+
+- Stream schemas are flat (stream entries are flat field-value pairs).
+- Only one index can be bound to a stream at a time; drop it before binding another.
+- Search's document limit applies to stream entries: at the limit, `XADD` to the indexed stream can fail.
+
 ### Create with Options
 
 ```typescript
@@ -87,7 +127,7 @@ const untypedIndex = redis.search.index({ name: "products" });
 const description = await index.describe();
 // {
 //   name: "products",
-//   dataType: "json",
+//   dataType: "json", // "hash" | "string" | "json" | "stream"
 //   prefixes: ["product:"],
 //   language: "english",
 //   schema: { name: { type: "TEXT" }, price: { type: "F64", fast: true } }

--- a/skills/search/overview.md
+++ b/skills/search/overview.md
@@ -85,7 +85,7 @@ For detailed usage of each command category, see:
 
 ### Data is upserted with regular Redis commands, not through search
 
-There is no `index.upsert()` or `index.add()` method. You store data using standard Redis commands (`set`, `json.set`, `hset`), and the search index automatically picks up keys matching its prefix.
+There is no `index.upsert()` or `index.add()` method. You store data using standard Redis commands (`set`, `json.set`, `hset`, or `xadd` for stream indexes), and the search index automatically picks up keys matching its prefix (or entries of its stream).
 
 ```typescript
 // Create the index


### PR DESCRIPTION
## Summary
Adds support for [search indexes over Redis streams](https://upstash.com/docs/redis/search/streams) (Redis 1.18).

```ts
const events = await redis.search.createIndex({
  name: "event-search",
  dataType: "stream",
  stream: "events", // exact stream key, replaces `prefix`
  schema: s.object({ message: s.string(), service: s.keyword(), severity: s.number("U64") }),
});

await redis.xadd("events", "*", { message: "Payment authorization failed", service: "checkout", severity: 4 });
await events.waitIndexing();
await events.query({ filter: { message: "authorization", severity: { $gte: 3 } } });
// [{ key: "<entry id>", score, data: { message, service, severity: 4 } }]
```

## Changes
- `CreateIndexParameters` gets a `dataType: "stream"` variant: `stream: string` is required, `prefix` is disallowed at the type level, and the schema is flat (same as hash).
- `buildCreateIndexCommand` emits `ON STREAM <key>` instead of `ON <TYPE> PREFIX n ...`.
- `IndexDescription.dataType` now includes `"stream"`; for stream indexes the server reports the stream key in `prefixes`, which is documented on the field.
- Querying, counting, aggregating and dropping need no changes: the document key is the entry ID, and numeric fields are parsed the same way as for hash indexes.
- `skills/search` docs: new "Create a Stream Index" section.
- Minor changeset.

## Testing
- New `search-stream.test.ts`: create → `XADD` → query (filter, `select`, `orderBy`) → count, `describe()`, `XDEL` removing documents, `skipInitialScan`, `redis.search.createIndex`, plus compile-time checks that `prefix` is rejected and `stream` is required. It is kept separate from `search.test.ts` because that file's `beforeAll` drops every index, and each stream test uses at most one index at a time.
- Command-builder tests for the stream variant.
- **Run against a live Redis 1.18 database: 6/6 stream tests and all command-builder tests pass.** `tsc`, eslint and prettier are clean.

Linear: DX-3010