### PR TITLE
fix: preserve numeric member precision in GEOSEARCH

### DIFF
--- a/.changeset/fix-geosearch-member-precision.md
+++ b/.changeset/fix-geosearch-member-precision.md
@@ -1,0 +1,5 @@
+---
+"@upstash/redis": patch
+---
+
+Prevent precision loss in GEOSEARCH member IDs by using the existing response parser.

--- a/packages/redis/pkg/commands/geo_search.ts
+++ b/packages/redis/pkg/commands/geo_search.ts
@@ -1,3 +1,4 @@
+import { parseResponse } from "../util";
 import type { CommandOptions } from "./command.ts";
 import { Command } from "./command.ts";
 
@@ -89,23 +90,13 @@ export class GeoSearchCommand<
 
     const transform = (result: string[] | string[][]) => {
       if (!opts?.withCoord && !opts?.withDist && !opts?.withHash) {
-        return result.map((member) => {
-          try {
-            return { member: JSON.parse(member as string) };
-          } catch {
-            return { member };
-          }
-        });
+        return result.map((member) => ({ member: parseResponse<TMemberType>(member) }));
       }
       return result.map((members) => {
         let counter = 1;
         const obj = {} as any;
 
-        try {
-          obj.member = JSON.parse(members[0]);
-        } catch {
-          obj.member = members[0];
-        }
+        obj.member = parseResponse<TMemberType>(members[0]);
 
         if (opts.withDist) {
           obj.dist = Number.parseFloat(members[counter++]);

--- a/packages/redis/pkg/commands/geo_search_deserialization.test.ts
+++ b/packages/redis/pkg/commands/geo_search_deserialization.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { GeoSearchCommand } from "./geo_search.ts";
+
+const members: [string, unknown][] = [
+  ["9007199254740993", "9007199254740993"],
+  ["9223372036854775807", "9223372036854775807"],
+  ["Palermo", "Palermo"],
+  ["42", 42],
+  ['{"name":"Palermo"}', { name: "Palermo" }],
+];
+
+test.each(members)("deserializes member %s without metadata", (member, expected) => {
+  const command = new GeoSearchCommand([
+    "places",
+    { type: "FROMMEMBER", member },
+    { type: "BYRADIUS", radius: 200, radiusType: "KM" },
+    "ASC",
+  ]);
+
+  expect(command.deserialize([member])).toEqual([{ member: expected }]);
+});
+
+test.each(members)("deserializes member %s with metadata", (member, expected) => {
+  const command = new GeoSearchCommand([
+    "places",
+    { type: "FROMMEMBER", member },
+    { type: "BYRADIUS", radius: 200, radiusType: "KM" },
+    "ASC",
+    { withDist: true, withHash: true, withCoord: true },
+  ]);
+
+  expect(
+    command.deserialize([
+      [member, "88.5260", 3_479_099_956_230_698, ["13.361389338970184", "38.1155563954963"]],
+    ])
+  ).toEqual([
+    {
+      member: expected,
+      dist: 88.526,
+      hash: "3479099956230698",
+      coord: { long: 13.361_389_338_970_184, lat: 38.115_556_395_496_3 },
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

Use the existing `parseResponse` helper when deserializing GEOSEARCH members, both with and without optional metadata. This preserves member IDs that exceed JavaScript's safe integer range instead of losing precision through `JSON.parse`.

## Testing

- `bun test packages/redis/pkg/commands/geo_search_deserialization.test.ts` (10 passed)
- `pnpm run ci:lint`
- `pnpm -r build`

The full integration suite reaches tests that require `UPSTASH_REDIS_REST_URL`, which is not available locally; the clean upstream branch stops at the same credential check.
